### PR TITLE
Add namespace option

### DIFF
--- a/dspcap-start
+++ b/dspcap-start
@@ -51,5 +51,5 @@ spec:
           privileged: true
 EOF
 
-kubectl rollout status daemonset/dspcap
+kubectl rollout status daemonset/dspcap -n default
 echo "Capture started. Use dspcap-stop to stop capture and collect outcome."

--- a/dspcap-start
+++ b/dspcap-start
@@ -3,13 +3,14 @@ set -e
 set -o pipefail
 STARTTIME=$(date -u +%Y-%m-%dT%H:%M)
 PIDFILE=/var/run/dspcap.pid
+NAMESPACE=default
 
 cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dspcap
-  namespace: default
+  namespace: $NAMESPACE
 spec:
   selector:
     matchLabels:
@@ -51,5 +52,5 @@ spec:
           privileged: true
 EOF
 
-kubectl rollout status daemonset/dspcap -n default
+kubectl rollout status daemonset/dspcap -n $NAMESPACE
 echo "Capture started. Use dspcap-stop to stop capture and collect outcome."

--- a/dspcap-stop
+++ b/dspcap-stop
@@ -11,24 +11,25 @@ EOF
 )"
 TAR_COMMAND="cd /tmp && tar zvc dspcap"
 DEL_COMMAND="rm -rf /tmp/dspcap"
+NAMESPACE=default
 
-pods=`kubectl get po -n default -l app=dspcap -o name`
+pods=`kubectl get po -n $NAMESPACE -l app=dspcap -o name`
 
 for po in `echo "$pods"`; do
   echo "run killing for $po"
-  kubectl exec -n default "$po" -- bash -c "$KILL_COMMAND"
+  kubectl exec -n $NAMESPACE "$po" -- bash -c "$KILL_COMMAND"
 done
 
 for po in `echo "$pods"`; do
   echo "downloading for $po"
-  kubectl exec -n default "$po" -- bash -c "$TAR_COMMAND" | tar zvx
+  kubectl exec -n $NAMESPACE "$po" -- bash -c "$TAR_COMMAND" | tar zvx
 done
 
 for po in `echo "$pods"`; do
   echo "cleanup for $po"
-  kubectl exec -n default "$po" -- bash -c "$DEL_COMMAND"
+  kubectl exec -n $NAMESPACE "$po" -- bash -c "$DEL_COMMAND"
 done
 
-kubectl delete -n default ds/dspcap
+kubectl delete -n $NAMESPACE ds/dspcap
 
 echo "All done, cheers."

--- a/dspcap-stop
+++ b/dspcap-stop
@@ -12,23 +12,23 @@ EOF
 TAR_COMMAND="cd /tmp && tar zvc dspcap"
 DEL_COMMAND="rm -rf /tmp/dspcap"
 
-pods=`kubectl get po -l app=dspcap -o name`
+pods=`kubectl get po -n default -l app=dspcap -o name`
 
 for po in `echo "$pods"`; do
   echo "run killing for $po"
-  kubectl exec "$po" -- bash -c "$KILL_COMMAND"
+  kubectl exec -n default "$po" -- bash -c "$KILL_COMMAND"
 done
 
 for po in `echo "$pods"`; do
   echo "downloading for $po"
-  kubectl exec "$po" -- bash -c "$TAR_COMMAND" | tar zvx
+  kubectl exec -n default "$po" -- bash -c "$TAR_COMMAND" | tar zvx
 done
 
 for po in `echo "$pods"`; do
   echo "cleanup for $po"
-  kubectl exec "$po" -- bash -c "$DEL_COMMAND"
+  kubectl exec -n default "$po" -- bash -c "$DEL_COMMAND"
 done
 
-kubectl delete ds/dspcap
+kubectl delete -n default ds/dspcap
 
 echo "All done, cheers."


### PR DESCRIPTION
kubectl can't find DaemonSet/Pod if current context is not set as default namespace. This PR fixes this problem.

```bash
% kubectl config set-context --current --namespace=namespace01
Context "myCluster" modified.
% ./dspcap-start
daemonset.apps/dspcap created
Error from server (NotFound): daemonsets.apps "dspcap" not found
```