### PR TITLE
Changed to have to specify namespace and context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A humble bash script set that uses daemonset to capture tcpdump from all k8s nod
 
 As simple as:
 
-1. Call `dspcap-start` script to start capture.
-2. Call `dspcap-stop` script to stop capture and collect result to `dspcap` directory.
+1. Call `dspcap-start context-name kubernetes-namespace` script to start capture.
+2. Call `dspcap-stop context-name kubernetes-namespace` script to stop capture and collect result to `dspcap` directory.
 
 ## Finetune tcpdump command
 

--- a/dspcap-start
+++ b/dspcap-start
@@ -1,11 +1,19 @@
 #!/bin/bash
+
+if [ $# -ne 2 ]; then
+echo "./dspcap clustercontext k8snamespace"
+echo "ex: ./dspcap aks-je2029stblue-001 default"
+exit 1
+fi
+
 set -e 
 set -o pipefail
 STARTTIME=$(date -u +%Y-%m-%dT%H:%M)
 PIDFILE=/var/run/dspcap.pid
-NAMESPACE=default
+NAMESPACE=$2
+CONTEXT=$1
 
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply --context $CONTEXT --namespace $NAMESPACE -f -
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/dspcap-stop
+++ b/dspcap-stop
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+if [ $# -ne 2 ]; then
+echo "./dspcap clustercontext k8snamespace"
+echo "ex: ./dspcap aks-je2029stblue-001 default"
+exit 1
+fi
+
 set -e 
 set -o pipefail
 PIDFILE=/var/run/dspcap.pid
@@ -11,25 +18,26 @@ EOF
 )"
 TAR_COMMAND="cd /tmp && tar zvc dspcap"
 DEL_COMMAND="rm -rf /tmp/dspcap"
-NAMESPACE=default
+NAMESPACE=$2
+CONTEXT=$1
 
-pods=`kubectl get po -n $NAMESPACE -l app=dspcap -o name`
+pods=`kubectl get po --context $CONTEXT -n $NAMESPACE -l app=dspcap -o name`
 
 for po in `echo "$pods"`; do
   echo "run killing for $po"
-  kubectl exec -n $NAMESPACE "$po" -- bash -c "$KILL_COMMAND"
+  kubectl exec --context $CONTEXT  -n $NAMESPACE "$po" -- bash -c "$KILL_COMMAND"
 done
 
 for po in `echo "$pods"`; do
   echo "downloading for $po"
-  kubectl exec -n $NAMESPACE "$po" -- bash -c "$TAR_COMMAND" | tar zvx
+  kubectl exec --context $CONTEXT -n $NAMESPACE "$po" -- bash -c "$TAR_COMMAND" | tar zvx
 done
 
 for po in `echo "$pods"`; do
   echo "cleanup for $po"
-  kubectl exec -n $NAMESPACE "$po" -- bash -c "$DEL_COMMAND"
+  kubectl exec --context $CONTEXT -n $NAMESPACE "$po" -- bash -c "$DEL_COMMAND"
 done
 
-kubectl delete -n $NAMESPACE ds/dspcap
+kubectl delete --context $CONTEXT -n $NAMESPACE ds/dspcap
 
 echo "All done, cheers."


### PR DESCRIPTION
I want you to make it mandatory to specify the namespace and context.
I find it very dangerous to run a script whose namespace and context are not named. We operate hundreds of Kubernetes clusters on our system, and without explicit context, operators run the risk of accidentally capturing packets in different environments. You may also not be able to deploy privileged containers in the default namespace on clusters that have Pod Security Standards applied.