### PR TITLE
Add a line to the start script.

### DIFF
--- a/dspcap-start
+++ b/dspcap-start
@@ -38,6 +38,7 @@ spec:
         - -xc
         - |
           mkdir -p /tmp/dspcap
+          chmod 777 /tmp/dspcap
           echo "starting pcap"
           tcpdump $TCPDUMP_ARGS -w "/tmp/dspcap/$STARTTIME.\$(hostname).pcap" &
           echo \$! >$PIDFILE


### PR DESCRIPTION
hello, 

Can you please add this line "chmod 777 /tmp/dspcap"  to the command on the start script  after the  mkdir -p  /tmp/dspcap line?

The reason for this is because I am getting permission errors when running the scrip, this is because the directory gets created with these persmissions shown below.

$ tcpdump -i any -s 100 -C 100 -w /tmp/dspcap/2023-04-01T19:07.aks-default-23507695-vmss000009.pcap tcpdump: data link type LINUX_SLL2
tcpdump: /tmp/dspcap/2023-04-01T19:07.aks-default-23507695-vmss000009.pcap: Permission denied


$ ll -d /tmp/dspcap/
drwxr-xr-x 2 root root 4096 Apr  1 19:07 /tmp/dspcap/   <<<<  Dir Permissions.

The file is created by user  tcpdump which does not have permissions over the  /tmp/dspcap  Dir.

$ tcpdump -i any -s 100 -C 100 -w /tmp/test.pcap
tcpdump: data link type LINUX_SLL2
tcpdump: listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 100 bytes ^C198 packets captured
532 packets received by filter
0 packets dropped by kernel

$ ll /tmp/test.pcap
-rw-r--r-- 1 tcpdump tcpdump 19830 Apr  1 19:24 /tmp/test.pcap    <<<<< User tcpdump


So the issue is that User creating the  pcap file "tcpdump User" does not have write permissions over the /tpm/dspcap  Dir.

Hope I am not totally wrong.

Thanks
Luis Alvarez.